### PR TITLE
Allow use of != base instead of unittest.TestCase

### DIFF
--- a/cricri/cricri.py
+++ b/cricri/cricri.py
@@ -316,7 +316,7 @@ class MetaTestState(type):
 
             mcs._build_str_method(attrs)
             test_case_list.append(type(''.join(scenario),
-                                       (unittest.TestCase,) + step.__bases__,
+                                       (cls.TestCase,) + step.__bases__,
                                        attrs))
         return test_case_list
 
@@ -415,6 +415,8 @@ class TestState(metaclass=MetaTestState):
             def input(self):
                 type(self).machine.m1()
     """
+    
+    TestCase = unittest.TestCase
 
 
 class MetaServerTestState(MetaTestState):

--- a/cricri/cricri.py
+++ b/cricri/cricri.py
@@ -234,7 +234,7 @@ class MetaTestState(type):
         if valids_inputs:
             return valids_inputs[0]
 
-    def _set_mtd(cls, mtd_name, attrs, key_name):
+    def _set_mtd(cls, mtd_name, attrs, key_name, super_at_start=True):
         """
         Add mtd_name to attrs dict.
 
@@ -245,7 +245,19 @@ class MetaTestState(type):
             if not isinstance(mtd, types.MethodType):
                 raise TypeError("{}.{} must be a classmethod"
                                 .format(cls, mtd_name))
-            attrs[key_name] = mtd
+            unbound_super = getattr(cls.TestCase, key_name).__func__
+
+            if super_at_start:
+                def func(cls):
+                    unbound_super(cls)
+                    mtd()
+            else:
+                def func(cls):
+                    mtd()
+                    unbound_super(cls)
+
+            func.__name__ = key_name
+            attrs[key_name] = classmethod(func)
 
     @classmethod
     def _build_str_method(mcs, attrs):
@@ -311,8 +323,8 @@ class MetaTestState(type):
 
                 previous_steps_names.append(step_name)
 
-            cls._set_mtd('start_scenario', attrs, 'setUpClass')
-            cls._set_mtd('stop_scenario', attrs, 'tearDownClass')
+            cls._set_mtd('start_scenario', attrs, 'setUpClass', True)
+            cls._set_mtd('stop_scenario', attrs, 'tearDownClass', False)
 
             mcs._build_str_method(attrs)
             test_case_list.append(type(''.join(scenario),

--- a/test/test_func_cricri.py
+++ b/test/test_func_cricri.py
@@ -44,6 +44,53 @@ class SpyTestState(unittest.TestCase):
                                  'Actual: {}\n'.format(calls, spy.mock_calls))
 
 
+class TestCaseTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        spy('TestCaseTest.setUpClass')
+
+    @classmethod
+    def tearDownClass(cls):
+        spy('TestCaseTest.tearDownClass')
+        super().tearDownClass()
+
+
+class TestCustomTestCase(SpyTestState):
+
+
+    class BaseTestState(TestState):
+        TestCase = TestCaseTest
+
+        @classmethod
+        def start_scenario(cls):
+            spy('BaseTestState.start_scenario')
+
+        @classmethod
+        def stop_scenario(cls):
+            spy('BaseTestState.stop_scenario')
+        
+    class A(BaseTestState, start=True):
+        def input(self):
+            pass
+
+    class B(BaseTestState, previous=['A']):
+        def input(self):
+            pass
+
+        def test_1(self):
+            spy("B1.test")
+
+    def test_execute_setup_teardown(self):
+        self.assertExec('AB', (
+            "TestCaseTest.setUpClass",
+            "BaseTestState.start_scenario",
+            "B1.test",
+            "BaseTestState.stop_scenario",
+            "TestCaseTest.tearDownClass",
+        ))
+
+
 class TestPreviousOnTestMethod(SpyTestState):
 
     class BaseTestState(TestState):
@@ -394,3 +441,4 @@ class TestShouldRaiseIfPreviousStepDoesntExist(unittest.TestCase):
                          "The previous `X` defined in"
                          " TestShouldRaiseIfPreviousStepDoesntExist.B class"
                          " doesn't exist")
+


### PR DESCRIPTION
This commit simply define the base class to use as an attribute of `TestState`. Named `TestCase`, it is defined by default to `unittest.TestCase`.

It's this attribute that is used as a base class when creating the class for a scenario, instead of the previously hardcoded `unittest.TestCase`.

The user can now use it's own subclass (with it's own method, etc...)

The second commit correctly call `super` in the dynamically generated methods `setUpClass` and `tearDownClass`.

And the last one add a simple test for all of this.